### PR TITLE
orderBy('\_name') cursor now only accept full doc path, if input type…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # HISTORY
 
+## v1.3.0 6-May-2022
+
+- orderBy('\_name') cursor now only accept full doc path, if input type is string, require const assertion or else display "Please use const assertion" error message.
+
+## v1.2.1 6-May-2022
+
+- fix cursor runtime not usable bug https://github.com/tylim88/Firelordjs/issues/51
+
 ## v1.2.0 5-May-2022
 
 - fix cursor not able to use with query document snapshot and document snapshot https://github.com/tylim88/Firelordjs/issues/51

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@
 
 <br/>
 
+> FirelordJS is the only library that capable of providing insane type safety while exposing all the API of the original Firestore SDK.
+>
+> FirelordJS has the lowest learning curve, best type safety and possibly also the smallest.
+>
+> It is what you are looking at: the Master of Fire.
+>
+> Note: let me know if you found anything that is better than this.
+
 support [@firebase/rules-unit-testing](https://firelordjs.com/tests)
 
 The development code, built code and published code are all tested in ci.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "firelordjs",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "firelordjs",
-			"version": "1.2.0",
+			"version": "1.2.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@firebase/rules-unit-testing": "^2.0.2",
@@ -26,7 +26,7 @@
 				"eslint-plugin-prettier": "^4.0.0",
 				"firebase": "^9.7.0",
 				"husky": "^7.0.0",
-				"jest": "^27.2.5",
+				"jest": "^27.5.1",
 				"jsdoc": "^3.6.5",
 				"lodash": "^4.17.21",
 				"parcel": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "firelordjs",
-	"version": "1.2.1",
+	"version": "1.3.0",
 	"description": "🔥 Extremely High Precision Typescript Wrapper for Firestore Web, Providing Unparalleled Type Safe and Dev Experience",
 	"source": "src/index.ts",
 	"main": "dist/src/index.js",
@@ -71,7 +71,7 @@
 		"eslint-plugin-prettier": "^4.0.0",
 		"firebase": "^9.7.0",
 		"husky": "^7.0.0",
-		"jest": "^27.2.5",
+		"jest": "^27.5.1",
 		"jsdoc": "^3.6.5",
 		"lodash": "^4.17.21",
 		"parcel": "^2.3.2",

--- a/src/queryClauses/orderBy.test.ts
+++ b/src/queryClauses/orderBy.test.ts
@@ -169,6 +169,25 @@ it('Too many arguments provided to startAt/startAfter/endAt/endBefore(). The num
 			endAt(1, ParentDocumentSnapshot)
 		)
 	).toThrow() // the only value __name__ can use for cursor is full doc path
+
+	query(
+		ref,
+		orderBy('a.b.c'),
+		orderBy('__name__'),
+		limit(1),
+		startAt(1),
+		// @ts-expect-error
+		endAt(1, 'topLevel/FirelordTest/Users/123')
+	)
+
+	query(
+		ref,
+		orderBy('a.b.c'),
+		orderBy('__name__'),
+		limit(1),
+		startAt(1), // @ts-expect-error
+		endAt(UserQueryDocumentSnapshot, 'a/123')
+	)
 })
 it('Too many arguments provided to startAt/startAfter/endAt/endBefore(). The number of arguments must be less than or equal to the number of orderBy() clauses, positive case', () => {
 	// cursor with has x number of arguments must has x number of orderBy clause before that cursor
@@ -215,7 +234,7 @@ it('Too many arguments provided to startAt/startAfter/endAt/endBefore(). The num
 		orderBy('__name__'),
 		limit(1),
 		startAt(1),
-		endAt(1, 'a/123')
+		endAt(1, `topLevel/FirelordTest/Users/123` as const)
 	)
 
 	query(
@@ -232,6 +251,6 @@ it('Too many arguments provided to startAt/startAfter/endAt/endBefore(). The num
 		orderBy('__name__'),
 		limit(1),
 		startAt(1),
-		endAt(UserQueryDocumentSnapshot, 'a/123')
+		endAt(UserQueryDocumentSnapshot, `topLevel/FirelordTest/Users/123` as const)
 	)
 })

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -77,6 +77,8 @@ export type ErrorWhereDocumentFieldPath =
 	'If field path is document ID, then value must be string'
 export type ErrorWhere__name__ =
 	"Error: Dont use ( __name__ ) directly as where's field path, use documentId() sentinel field path instead."
+export type ErrorCursor__name__ =
+	'Error: detected type is string, please do const assertion'
 
 export type ErrorMsgs =
 	| ErrorUndefined
@@ -111,6 +113,7 @@ export type ErrorMsgs =
 	| ErrorWhereDocumentFieldPath
 	| ErrorWhere__name__
 	| ErrorWhereNoNeverEmptyArray
+	| ErrorCursor__name__
 
 export type ReplaceErrorMsgsWithNever<T> = T extends ErrorMsgs ? never : T // ! not yet implemented anywhere
 


### PR DESCRIPTION
… is string, require const assertion or else display "Please use const assertion" error message.